### PR TITLE
Static files dir in project root

### DIFF
--- a/hittade/settings.py
+++ b/hittade/settings.py
@@ -141,6 +141,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
+STATICFILES_DIRS = [BASE_DIR / "static"]
+
 STATIC_URL = "static/"
 
 # Default primary key field type


### PR DESCRIPTION
In preparation for needing static files for the project, this PR configures `hittade`'s static dir to be in the project root. (Empty for now)

The static dir _could_ go in the one of the app dirs (`server/`. `containers/`), but I'd personally argue against this based on that most static files will not be app-specific. It is very possible there is a reason we wouldn't want to do this though, let me know! Alternatively, the static dir could go in the main `hittade/` directory. 

In my mind this thinking would also apply to shared templates or partials, but that's a separate topic :)