### PR TITLE
Configure SASS in web container

### DIFF
--- a/.docker/scripts/setup-sass.sh
+++ b/.docker/scripts/setup-sass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+VERSION=1.83.0;
+
+URL="https://github.com/sass/dart-sass/releases/download/${VERSION}/dart-sass-${VERSION}-linux-x64.tar.gz";
+
+mkdir -p /opt/dart-sass;
+
+curl -sL $URL | tar zx -C /opt;
+
+ln -s /opt/dart-sass/sass /usr/local/bin/sass;

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ db.sqlite*
 redis
 certificates
 db*
+
+# Bundled assets
+/static/css

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.11
 ENV PYTHONUNBUFFERED=1
 WORKDIR /code
+COPY .docker/ /code/.docker/
+RUN bash .docker/scripts/setup-sass.sh
 COPY requirements-dev.txt /code/
 RUN pip install -r requirements-dev.txt
 COPY . /code/

--- a/scripts/sass.sh
+++ b/scripts/sass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+INPUT_DIR="static/sass";
+OUTPUT_DIR="static/css";
+
+case $1 in 
+  dev) sass $INPUT_DIR:$OUTPUT_DIR --watch;;
+  build) sass $INPUT_DIR:$OUTPUT_DIR && echo "Successully built styles to $OUTPUT_DIR";;
+esac


### PR DESCRIPTION
Prepping for styling, here we add the [standalone Dart SASS](https://github.com/sass/dart-sass?tab=readme-ov-file#standalone) binary to the web container, along with a helper script (`scripts/sass.sh`), to watch/build the CSS.