### PR TITLE
Fix docker compose service startup order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,4 @@ services:
       - .:/code
     ports:
       - "8000:8000"
-    depends_on:
-      - redis
-      - db
+        

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       #- internal_network
     healthcheck:
       test: ['CMD', 'pg_isready', '-U', 'postgres']
+      interval: 30s
+      timeout: 60s
+      retries: 5
+      start_period: 80s 
     volumes:
       - ./db:/var/lib/postgresql/data
     environment:
@@ -20,6 +24,10 @@ services:
       #- internal_network
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
+      interval: 30s
+      timeout: 60s
+      retries: 5
+      start_period: 80s 
     volumes:
       - ./redis:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,11 @@ services:
   web:
     build: .
     image: docker.sunet.se/hittade-server:v0.0.1
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     command: ./docker-entrypoint.sh
     volumes:
       - .:/code


### PR DESCRIPTION
Often times the `web` service starts up before `db` is ready to accept connections, causing errors.

We fix this by making `web` dependant on both `db` and `redis` services having completed healthchecks before starting `web`.