### PR TITLE
Fix route `containers/package/<id>` being unauthenticated

### DIFF
--- a/containers/views.py
+++ b/containers/views.py
@@ -16,7 +16,8 @@ from .utils import latest_containers
 def index(request):
     return redirect(search)
 
-
+@login_required
+@permission_required("containers.view_containerbase", raise_exception=True)
 def package(request, pk):
     package = ContainerPackage.objects.get(pk=pk)
     latest = latest_containers()


### PR DESCRIPTION
This route should most likely require authentication. This pr adds checks for permissions and authetication.
